### PR TITLE
Fixed an issue where ForEachAssembly() didn't catch a TypeLoadException that can be thrown by GetCustomAttributes().

### DIFF
--- a/Editor/ConditionalCompilationUtility.cs
+++ b/Editor/ConditionalCompilationUtility.cs
@@ -213,7 +213,7 @@ namespace ConditionalCompilation
                 {
                     callback(assembly);
                 }
-                catch (ReflectionTypeLoadException)
+                catch (Exception ex) when (ex is ReflectionTypeLoadException || ex is TypeLoadException)
                 {
                     // Skip any assemblies that don't load properly
                     continue;


### PR DESCRIPTION
Hi 👋🏻. I use ConditionalCompilationUtility in a library called [3D WebView](https://developer.vuplex.com), and a user contacted me about an issue where an uncaught TypeLoadException was being thrown by ConditionalCompilationUtility. Here's the stack trace they sent me:

```
TypeLoadException: Could not resolve type with token 01000008 from typeref (expected class 'System.Resources.NeutralResourcesLanguageAttribute' in assembly 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a')
System.MonoCustomAttrs.GetCustomAttributesBase (System.Reflection.ICustomAttributeProvider obj, System.Type attributeType, System.Boolean inheritedOnly) (at <75633565436c42f0a6426b33f0132ade>:0)
System.MonoCustomAttrs.GetCustomAttributes (System.Reflection.ICustomAttributeProvider obj, System.Boolean inherit) (at <75633565436c42f0a6426b33f0132ade>:0)
System.Reflection.RuntimeAssembly.GetCustomAttributes (System.Boolean inherit) (at <75633565436c42f0a6426b33f0132ade>:0)
Vuplex.WebView.ConditionalCompilation.ConditionalCompilationUtility+<>c__DisplayClass9_0.<UpdateDependencies>b__1 (System.Reflection.Assembly assembly) (at Assets/Vuplex/WebView/Core/Editor/Scripts/ConditionalCompilationUtility.cs:191)
Vuplex.WebView.ConditionalCompilation.ConditionalCompilationUtility.ForEachAssembly (System.Action`1[T] callback) (at Assets/Vuplex/WebView/Core/Editor/Scripts/ConditionalCompilationUtility.cs:252)
Vuplex.WebView.ConditionalCompilation.ConditionalCompilationUtility.UpdateDependencies (System.Boolean reset) (at Assets/Vuplex/WebView/Core/Editor/Scripts/ConditionalCompilationUtility.cs:189)
```

I updated the version of CCU that ships with 3D WebView to incorporate the change in this PR and the user confirmed that it resolved the issue for them. I'm just submitting this change in a PR now to help others avoid it in the future.